### PR TITLE
Fix bugs identified during demo

### DIFF
--- a/.github/workflows/push-to-main-handler.yml
+++ b/.github/workflows/push-to-main-handler.yml
@@ -104,10 +104,6 @@ jobs:
           TODAYS_DATE=$(date +'%b %d, %Y')
           echo ::set-output name=RELEASE_DATE::$TODAYS_DATE
 
-      - name: Tag Main
-        if: steps.check_release.outputs.IS_RELEASE == 'true' && steps.requires-deploy.outputs.changed == '1'
-        run: git tag ${{ steps.current_tag.outputs.v_minor }}
-
       - name: Create Release
         if: steps.check_release.outputs.IS_RELEASE == 'true' && steps.requires-deploy.outputs.changed == '1'
         id: create_release

--- a/.github/workflows/push-to-main-handler.yml
+++ b/.github/workflows/push-to-main-handler.yml
@@ -15,9 +15,6 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.SCOPED_PAT }}
 
-      - name: Checkout tags
-        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-
       - name: Setup Node
         uses: actions/setup-node@377c6dae4006fcd73be5aac564ee449b1a5d63f7
         with:
@@ -86,7 +83,10 @@ jobs:
       - name: Get Previous Tag
         if: steps.check_release.outputs.IS_RELEASE == 'true' && steps.requires-deploy.outputs.changed == '1'
         id: previous_tag
-        uses: WyriHaximus/github-action-get-previous-tag@3f018b4126e1d6652bcb11a64cb505e341b70c2d
+        uses: WyriHaximus/github-action-get-previous-tag@b95747caec0c7a37825ed29640b4adcb6a8cd3fb
+        with:
+          fallback: 0.0.0
+          prefix: v
         env:
           GITHUB_TOKEN: ${{ secrets.SCOPED_PAT }}
 

--- a/.github/workflows/push-to-main-handler.yml
+++ b/.github/workflows/push-to-main-handler.yml
@@ -85,7 +85,7 @@ jobs:
         id: previous_tag
         uses: WyriHaximus/github-action-get-previous-tag@b95747caec0c7a37825ed29640b4adcb6a8cd3fb
         with:
-          fallback: 0.0.0
+          fallback: 1.0.0
           prefix: v
         env:
           GITHUB_TOKEN: ${{ secrets.SCOPED_PAT }}

--- a/.github/workflows/push-to-main-handler.yml
+++ b/.github/workflows/push-to-main-handler.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Authenticate DevHub
         if: steps.requires-deploy.outputs.changed == '1'
+        env:
+          SALESFORCE_JWT_SECRET_KEY: ${{ secrets.SALESFORCE_JWT_SECRET_KEY }}
         run: |
           echo "${SALESFORCE_JWT_SECRET_KEY}" > server.key
           npx sfdx-cli force:auth:jwt:grant --clientid ${{ secrets.SALESFORCE_CONSUMER_KEY }} --jwtkeyfile server.key --username ${{ secrets.SALESFORCE_DEVHUB_USERNAME}} --setdefaultdevhubusername -a DevHub

--- a/.github/workflows/push-to-main-handler.yml
+++ b/.github/workflows/push-to-main-handler.yml
@@ -88,7 +88,7 @@ jobs:
         id: previous_tag
         uses: WyriHaximus/github-action-get-previous-tag@3f018b4126e1d6652bcb11a64cb505e341b70c2d
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: ${{ secrets.SCOPED_PAT }}
 
       - name: Get Next Tag Version
         if: steps.check_release.outputs.IS_RELEASE == 'true' && steps.requires-deploy.outputs.changed == '1'
@@ -113,7 +113,7 @@ jobs:
         id: create_release
         uses: actions/create-release@c38d3a140cc22e67e265c5d5b6b4888d1f02533f
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SCOPED_PAT }}
         with:
           tag_name: ${{ steps.current_tag.outputs.v_patch }}
           release_name: ${{ steps.get_date.outputs.RELEASE_DATE }} Release

--- a/.github/workflows/push-to-main-handler.yml
+++ b/.github/workflows/push-to-main-handler.yml
@@ -50,9 +50,9 @@ jobs:
       - name: Authenticate DevHub
         if: steps.requires-deploy.outputs.changed == '1'
         env:
-          SALESFORCE_JWT_SECRET_KEY: ${{ secrets.SALESFORCE_JWT_SECRET_KEY }}
+          SALESFORCE_JWT_KEY: ${{ secrets.SALESFORCE_JWT_KEY }}
         run: |
-          echo "${SALESFORCE_JWT_SECRET_KEY}" > server.key
+          echo "${SALESFORCE_JWT_KEY}" > server.key
           npx sfdx-cli force:auth:jwt:grant --clientid ${{ secrets.SALESFORCE_CLIENT_ID }} --jwtkeyfile server.key --username ${{ secrets.SALESFORCE_DEVHUB_USERNAME}} --setdefaultdevhubusername -a DevHub
           npx sfdx-cli force:org:display --json -u DevHub > sfdx-auth.json
 

--- a/.github/workflows/push-to-main-handler.yml
+++ b/.github/workflows/push-to-main-handler.yml
@@ -111,7 +111,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.SCOPED_PAT }}
         with:
-          tag_name: ${{ steps.current_tag.outputs.v_major }}
+          tag_name: ${{ steps.current_tag.outputs.v_minor }}
           release_name: ${{ steps.get_date.outputs.RELEASE_DATE }} Release
           body_path: release-notes/release.md
           draft: false

--- a/.github/workflows/push-to-main-handler.yml
+++ b/.github/workflows/push-to-main-handler.yml
@@ -156,6 +156,5 @@ jobs:
 
             gh pr create --title "Clean up destructive changes" \
             --body "Please merge \`clean-up-destructive-changes-$RELEASE_DATE\` into \`main\` and delete \`clean-up-destructive-changes-$RELEASE_DATE\`." \
-            -H clean-up-destructive-changes-"$RELEASE_DATE" -B main \
-            -r github/salesforce-reviewers
+            -H clean-up-destructive-changes-"$RELEASE_DATE" -B main
           fi

--- a/.github/workflows/push-to-main-handler.yml
+++ b/.github/workflows/push-to-main-handler.yml
@@ -111,7 +111,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.SCOPED_PAT }}
         with:
-          tag_name: ${{ steps.current_tag.outputs.v_patch }}
+          tag_name: ${{ steps.current_tag.outputs.v_major }}
           release_name: ${{ steps.get_date.outputs.RELEASE_DATE }} Release
           body_path: release-notes/release.md
           draft: false

--- a/.github/workflows/push-to-main-handler.yml
+++ b/.github/workflows/push-to-main-handler.yml
@@ -53,7 +53,7 @@ jobs:
           SALESFORCE_JWT_SECRET_KEY: ${{ secrets.SALESFORCE_JWT_SECRET_KEY }}
         run: |
           echo "${SALESFORCE_JWT_SECRET_KEY}" > server.key
-          npx sfdx-cli force:auth:jwt:grant --clientid ${{ secrets.SALESFORCE_CONSUMER_KEY }} --jwtkeyfile server.key --username ${{ secrets.SALESFORCE_DEVHUB_USERNAME}} --setdefaultdevhubusername -a DevHub
+          npx sfdx-cli force:auth:jwt:grant --clientid ${{ secrets.SALESFORCE_CLIENT_ID }} --jwtkeyfile server.key --username ${{ secrets.SALESFORCE_DEVHUB_USERNAME}} --setdefaultdevhubusername -a DevHub
           npx sfdx-cli force:org:display --json -u DevHub > sfdx-auth.json
 
       - name: Recompose profiles

--- a/.github/workflows/release-branch-merge-handler.yml
+++ b/.github/workflows/release-branch-merge-handler.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Compile Release Notes
         if: steps.check_merge.outputs.IS_MERGE == 'true' && vars.GENERATE_RELEASE == 'true'
         run: |
-          if [ ls release-notes/${{ vars.ISSUE_BRANCH_PREFIX }}*.md 1> /dev/null 2>&1 ]
+          if [ -f release-notes/${{ vars.ISSUE_BRANCH_PREFIX }}*.md ]
           then
               if [ ! -f release-notes/release.md ]
               then

--- a/.github/workflows/release-branch-merge-handler.yml
+++ b/.github/workflows/release-branch-merge-handler.yml
@@ -32,19 +32,19 @@ jobs:
       - name: Compile Release Notes
         if: steps.check_merge.outputs.IS_MERGE == 'true' && vars.GENERATE_RELEASE == 'true'
         run: |
-          if [ls release-notes/${{ vars.ISSUE_BRANCH_PREFIX }}*.md 1> /dev/null 2>&1]
+          if [ ls release-notes/${{ vars.ISSUE_BRANCH_PREFIX }}*.md 1> /dev/null 2>&1 ]
           then
-              if [ ! -f $1 ]
+              if [ ! -f release-notes/release.md ]
               then
-                  echo "### Includes the following items" > $1
-                  echo >> $1
+                  echo "### Includes the following items" > release-notes/release.md
+                  echo >> release-notes/release.md
               fi
               for ISSUE_NOTES in `ls release-notes/${{ vars.ISSUE_BRANCH_PREFIX }}*.md`
               do
                   NOTES=`cat ${ISSUE_NOTES}`
-                  if ! grep -q "${NOTES}" $1
+                  if ! grep -q "${NOTES}" release-notes/release.md
                   then
-                      echo "${NOTES}" >> $1
+                      echo "${NOTES}" >> release-notes/release.md
                   fi
               done
           fi

--- a/.github/workflows/release-branch-merge-handler.yml
+++ b/.github/workflows/release-branch-merge-handler.yml
@@ -51,7 +51,10 @@ jobs:
       - name: Delete Artifacts
         if: steps.check_merge.outputs.IS_MERGE == 'true'
         run: |
-          if [${{ vars.GENERATE_RELEASE }} == 'true']; then rm release-notes/${{ vars.ISSUE_BRANCH_PREFIX }}*.md || true
+          if [ "${{ vars.GENERATE_RELEASE }}" = "true" ]
+          then
+            rm release-notes/${{ vars.ISSUE_BRANCH_PREFIX }}*.md || true
+          fi
           rm auth/sandbox-login-url-issue-* || true
       - uses: stefanzweifel/git-auto-commit-action@v4.15.4
         if: steps.check_merge.outputs.IS_MERGE == 'true'

--- a/.github/workflows/release-branch-pull-request-handler.yml
+++ b/.github/workflows/release-branch-pull-request-handler.yml
@@ -36,7 +36,6 @@ jobs:
       - name: Install sfdx Plugins
         if: steps.branchFilter.outputs.matches == 'true'
         run: |
-          echo y | npx sfdx-cli plugins:install sfdx-deliverability-access
           echo y | npx sfdx-cli plugins:install @rdietrick/sfdx-profile-decompose
       - name: Recompose Profiles
         if: steps.branchFilter.outputs.matches == 'true' && vars.SALESFORCE_FORMATTED_PROFILES_AND_PERMS == 'false'
@@ -72,10 +71,6 @@ jobs:
         run: |
           openssl enc -d -aes-256-cbc -in ${LOGIN_ENC_FILE}.enc -out ${LOGIN_ENC_FILE} -k ${{ secrets.SANDBOX_URL_ENCRYPTION_KEY }} -md sha256
           npx sfdx-cli force:auth:sfdxurl:store -f ${LOGIN_ENC_FILE} -a is${{ steps.branchFilter.outputs.issueNumber }}uat
-      - name: Set Email Deliverability Access Level to All Email
-        if: steps.branchFilter.outputs.matches == 'true' && steps.check_first_deploy.outputs.FIRST_DEPLOY == 'true'
-        run: |
-          npx sfdx-cli deliverability:access --level All -u is${{ steps.branchFilter.outputs.issueNumber }}uat
       - name: Deploy Source to Sandbox
         if: steps.branchFilter.outputs.matches == 'true'
         env:

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -39,3 +39,5 @@ The following repository variables are required to be set in the repository sett
   - This is feature flag that is a boolean value that determines whether release notes should be generated.
 - `SALESFORCE_FORMATTED_PROFILES_AND_PERMS`
   - This is a feature flag that is a boolean value that determines whether profiles and permissions should be formatted using the `profile:decompose` plugin.
+- `DEPLOYMENT_TIMEOUT`
+  - The number of minutes to wait for the `force:source:deploy` command to complete and display results.

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -18,8 +18,6 @@ The following secrets are required to be set in the repository settings:
   - This is the consumer key of the template org. This is used to authenticate with the template sandbox.
 - `SALESFORCE_TEMPLATE_USERNAME`
   - This is the username of the template org. This is used to authenticate with the template sandbox.
-- `SALESFORCE_TEMPLATE_USERNAME`
-  - This is the username of the template org. This is used to authenticate with the template sandbox.
 - `SALESFORCE_TEMPLATE_JWT_SECRET_KEY`
   - This is the private key used to generate the JWT token. This is used to authenticate with the template sandbox.
 - `BOT_USER_EMAIL`

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -8,8 +8,6 @@ The following secrets are required to be set in the repository settings:
   - This is a personal access token with the `repo` scope. This is used to checkout the repository and push any changes.
 - `SALESFORCE_JWT_KEY`
   - This is the private key used to generate the JWT token. This is used to authenticate with Salesforce production.
-- `SALESFORCE_JWT_SECRET_KEY`
-  - This is the private key used to generate the JWT token. This is used to authenticate with Salesforce production.
 - `SALESFORCE_CLIENT_ID`
   - This is the client ID used to generate the JWT token. This is used to authenticate with Salesforce production.
 - `SALESFORCE_DEVHUB_USERNAME`


### PR DESCRIPTION
### Bug Fixes & Cleanup

`push-to-main-handler` workflow changes:
1. Remove reference to a secret that does not exist
1. Add missing environment variable for workflow step
1. Use scoped PAT instead of default GH token to create GH release because the default token does not have the appropriate perms to create a release 
1. Consolidate `SALESFORCE_JWT_KEY` and `SALESFORCE_JWT_SECRET_KEY` to mitigate confusion and redundancy
1. Remove tag checkout and `tag main` step because it is not necessary and use fallback semver when no tags exist
---
`release-branch-pull-request-handler` workflow changes:
1. Remove Email Deliverability plugin logic because of errors deriving from Chromium/Driver issues
---
`release-branch-merge-handler` workflow changes:
1. Fix bug in release note compilation step 