### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/push-to-main-handler.yml
+++ b/.github/workflows/push-to-main-handler.yml
@@ -35,9 +35,9 @@ jobs:
         run: |
           NOTE_FILES=$(git diff --name-only HEAD^ HEAD -- 'release-notes/release.md')
           if [ -z "$NOTE_FILES" ] ; then
-            echo "IS_RELEASE=false" >> $GITHUB_OUTPUT
+            echo "IS_RELEASE=false" >> "$GITHUB_OUTPUT"
           else
-            echo "IS_RELEASE=true" >> $GITHUB_OUTPUT
+            echo "IS_RELEASE=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install profile decompose sfdx plugin
@@ -65,13 +65,13 @@ jobs:
         run: |
           if [ -f destructive-changes/destructiveChangesPre.xml ] && [ -f destructive-changes/destructiveChangesPost.xml ]
           then 
-            echo "DESTRUCTIVE_FILES=--predestructivechanges destructive-changes/destructiveChangesPre.xml --postdestructivechanges destructive-changes/destructiveChangesPost.xml" >> $GITHUB_OUTPUT;
+            echo "DESTRUCTIVE_FILES=--predestructivechanges destructive-changes/destructiveChangesPre.xml --postdestructivechanges destructive-changes/destructiveChangesPost.xml" >> "$GITHUB_OUTPUT";
           elif [ -f destructive-changes/destructiveChangesPre.xml ]
           then 
-            echo "DESTRUCTIVE_FILES=--predestructivechanges destructive-changes/destructiveChangesPre.xml" >> $GITHUB_OUTPUT;
+            echo "DESTRUCTIVE_FILES=--predestructivechanges destructive-changes/destructiveChangesPre.xml" >> "$GITHUB_OUTPUT";
           elif [ -f destructive-changes/destructiveChangesPost.xml ]
           then 
-            echo "DESTRUCTIVE_FILES=--postdestructivechanges destructive-changes/destructiveChangesPost.xml" >> $GITHUB_OUTPUT;
+            echo "DESTRUCTIVE_FILES=--postdestructivechanges destructive-changes/destructiveChangesPost.xml" >> "$GITHUB_OUTPUT";
           fi
 
       - name: Deploy to Production
@@ -102,7 +102,7 @@ jobs:
         id: get_date
         run: |
           TODAYS_DATE=$(date +'%b %d, %Y')
-          echo "RELEASE_DATE=$TODAYS_DATE" >> $GITHUB_OUTPUT
+          echo "RELEASE_DATE=$TODAYS_DATE" >> "$GITHUB_OUTPUT"
 
       - name: Create Release
         if: steps.check_release.outputs.IS_RELEASE == 'true' && steps.requires-deploy.outputs.changed == '1'

--- a/.github/workflows/push-to-main-handler.yml
+++ b/.github/workflows/push-to-main-handler.yml
@@ -35,9 +35,9 @@ jobs:
         run: |
           NOTE_FILES=$(git diff --name-only HEAD^ HEAD -- 'release-notes/release.md')
           if [ -z "$NOTE_FILES" ] ; then
-            echo ::set-output name=IS_RELEASE::false
+            echo "IS_RELEASE=false" >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=IS_RELEASE::true
+            echo "IS_RELEASE=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Install profile decompose sfdx plugin
@@ -102,7 +102,7 @@ jobs:
         id: get_date
         run: |
           TODAYS_DATE=$(date +'%b %d, %Y')
-          echo ::set-output name=RELEASE_DATE::$TODAYS_DATE
+          echo "RELEASE_DATE=$TODAYS_DATE" >> $GITHUB_OUTPUT
 
       - name: Create Release
         if: steps.check_release.outputs.IS_RELEASE == 'true' && steps.requires-deploy.outputs.changed == '1'

--- a/.github/workflows/release-branch-pull-request-handler.yml
+++ b/.github/workflows/release-branch-pull-request-handler.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           if [ -f release-notes/${{ vars.ISSUE_BRANCH_PREFIX }}${{ steps.branchFilter.outputs.issueNumber }}.md ]
           then
-            echo "FIRST_DEPLOY=false" >> $GITHUB_OUTPUT; else echo "FIRST_DEPLOY=true" >> $GITHUB_OUTPUT;
+            echo "FIRST_DEPLOY=false" >> "$GITHUB_OUTPUT"; else echo "FIRST_DEPLOY=true" >> "$GITHUB_OUTPUT";
           fi
       - name: Generate Destructive Changes Param
         if: steps.branchFilter.outputs.matches == 'true' && steps.requires-deploy.outputs.changed == '1' && steps.check_first_deploy.outputs.FIRST_DEPLOY == 'true'
@@ -62,13 +62,13 @@ jobs:
         run: |
           if [ -f destructive-changes/destructiveChangesPre.xml ] && [ -f destructive-changes/destructiveChangesPost.xml ]
           then 
-            echo "DESTRUCTIVE_FILES=--predestructivechanges destructive-changes/destructiveChangesPre.xml --postdestructivechanges destructive-changes/destructiveChangesPost.xml" >> $GITHUB_OUTPUT;
+            echo "DESTRUCTIVE_FILES=--predestructivechanges destructive-changes/destructiveChangesPre.xml --postdestructivechanges destructive-changes/destructiveChangesPost.xml" >> "$GITHUB_OUTPUT";
           elif [ -f destructive-changes/destructiveChangesPre.xml ]
           then 
-            echo "DESTRUCTIVE_FILES=--predestructivechanges destructive-changes/destructiveChangesPre.xml" >> $GITHUB_OUTPUT;
+            echo "DESTRUCTIVE_FILES=--predestructivechanges destructive-changes/destructiveChangesPre.xml" >> "$GITHUB_OUTPUT";
           elif [ -f destructive-changes/destructiveChangesPost.xml ]
           then 
-            echo "DESTRUCTIVE_FILES=--postdestructivechanges destructive-changes/destructiveChangesPost.xml" >> $GITHUB_OUTPUT;
+            echo "DESTRUCTIVE_FILES=--postdestructivechanges destructive-changes/destructiveChangesPost.xml" >> "$GITHUB_OUTPUT";
           fi
       - name: Authenticate to UAT Sandbox
         if: steps.branchFilter.outputs.matches == 'true' && steps.requires-deploy.outputs.changed == '1'
@@ -105,7 +105,7 @@ jobs:
           ISSUE_JSON="${ISSUE_JSON//'%'/'%25'}"
           ISSUE_JSON="${ISSUE_JSON//$'\n'/'%0A'}"
           ISSUE_JSON="${ISSUE_JSON//$'\r'/'%0D'}"
-          echo "ISSUE=$ISSUE_JSON" >> $GITHUB_OUTPUT;
+          echo "ISSUE=$ISSUE_JSON" >> "$GITHUB_OUTPUT";
           rm issue.json
       - uses: stefanzweifel/git-auto-commit-action@v4.15.4
         if: vars.GENERATE_RELEASE == 'true' && steps.check_first_deploy.outputs.FIRST_DEPLOY == 'true' && steps.branchFilter.outputs.matches == 'true'


### PR DESCRIPTION
`save-state` and `set-output` commands [used in GitHub Actions are deprecated](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


