### PR TITLE
Fix potential Actions injection

### DIFF
--- a/.github/workflows/issue-branch-creation-handler.yml
+++ b/.github/workflows/issue-branch-creation-handler.yml
@@ -53,11 +53,13 @@ jobs:
         id: extract_branch
       - name: Create Dev Sandbox
         if: steps.branchFilter.outputs.matches == 'true'
+        env:
+          BRANCH: ${{ steps.extract_branch.outputs.branch }}
         run: |
           set +e
           npx sf env create sandbox --clone Template \
             --name is${{ steps.branchFilter.outputs.issueNumber }} \
-            --alias ${{ steps.extract_branch.outputs.branch }} \
+            --alias $BRANCH \
             --target-org DevHub --async --no-prompt
           if [ $? -eq 68 ]
           then
@@ -67,11 +69,13 @@ jobs:
           fi
       - name: Create UAT Sandbox
         if: steps.branchFilter.outputs.matches == 'true'
+        env:
+          BRANCH: ${{ steps.extract_branch.outputs.branch }}
         run: |
           set +e
           npx sf env create sandbox --clone Template \
             --name is${{ steps.branchFilter.outputs.issueNumber }}uat \
-            --alias ${{ steps.extract_branch.outputs.branch }}-uat \
+            --alias ${BRANCH}-uat \
             --target-org DevHub --async --no-prompt
           if [ $? -eq 68 ]
           then

--- a/.github/workflows/release-branch-pull-request-handler.yml
+++ b/.github/workflows/release-branch-pull-request-handler.yml
@@ -94,8 +94,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.SCOPED_PAT }}
           ISSUE_URL: https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.branchFilter.outputs.issueNumber }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          git fetch origin ${{ github.head_ref }}
+          git fetch origin $HEAD_REF
           curl -H "Authorization: Bearer ${GITHUB_TOKEN}" -s ${ISSUE_URL} > issue.json
           ISSUE_HTML_URL=$(jq -r '.html_url' issue.json)
           ISSUE_TITLE=$(jq -r '.title' issue.json)


### PR DESCRIPTION
Branch names are user-controlled values that can store special characters like `;` allowing for command injection. By storing the branch names as environment variables, the interpolation is not done at the workflow level, instead, it's treated like a variable by bash.